### PR TITLE
refactor : remove unused LGTM Continers

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -131,11 +131,6 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-grafana</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/api-gateway/src/test/java/com/example/api/gateway/config/ContainerConfig.java
+++ b/api-gateway/src/test/java/com/example/api/gateway/config/ContainerConfig.java
@@ -7,22 +7,13 @@
 package com.example.api.gateway.config;
 
 import com.redis.testcontainers.RedisContainer;
-import java.time.Duration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class ContainerConfig {
-
-    @Bean
-    @ServiceConnection
-    LgtmStackContainer lgtmContainer() {
-        return new LgtmStackContainer(DockerImageName.parse("grafana/otel-lgtm:0.30.1"))
-                .withStartupTimeout(Duration.ofMinutes(2));
-    }
 
     @Bean
     @ServiceConnection(name = "redis")

--- a/inventory-service/pom.xml
+++ b/inventory-service/pom.xml
@@ -200,11 +200,6 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-grafana</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/inventory-service/src/test/java/com/example/inventoryservice/common/NonSQLContainersConfig.java
+++ b/inventory-service/src/test/java/com/example/inventoryservice/common/NonSQLContainersConfig.java
@@ -6,23 +6,14 @@
 
 package com.example.inventoryservice.common;
 
-import java.time.Duration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class NonSQLContainersConfig {
-
-    @Bean
-    @ServiceConnection
-    LgtmStackContainer lgtmContainer() {
-        return new LgtmStackContainer(DockerImageName.parse("grafana/otel-lgtm:0.30.1"))
-                .withStartupTimeout(Duration.ofMinutes(2));
-    }
 
     @Bean
     @ServiceConnection

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -236,11 +236,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-grafana</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock.integrations</groupId>
             <artifactId>wiremock-spring-boot</artifactId>
             <version>4.2.2</version>

--- a/order-service/src/test/java/com/example/orderservice/common/ContainersConfig.java
+++ b/order-service/src/test/java/com/example/orderservice/common/ContainersConfig.java
@@ -6,12 +6,10 @@
 
 package com.example.orderservice.common;
 
-import java.time.Duration;
 import org.springframework.boot.devtools.restart.RestartScope;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -24,13 +22,5 @@ public class ContainersConfig {
     KafkaContainer kafkaContainer() {
         return new KafkaContainer(DockerImageName.parse("apache/kafka-native").withTag("4.3.1"))
                 .withReuse(true);
-    }
-
-    @Bean
-    @ServiceConnection
-    @RestartScope
-    LgtmStackContainer lgtmContainer() {
-        return new LgtmStackContainer(DockerImageName.parse("grafana/otel-lgtm:0.30.1"))
-                .withStartupTimeout(Duration.ofMinutes(2));
     }
 }

--- a/payment-service/pom.xml
+++ b/payment-service/pom.xml
@@ -159,11 +159,6 @@
             <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers-grafana</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/payment-service/src/test/java/com/example/paymentservice/common/NonSQLContainerConfig.java
+++ b/payment-service/src/test/java/com/example/paymentservice/common/NonSQLContainerConfig.java
@@ -1,23 +1,14 @@
 /*** Licensed under MIT License Copyright (c) 2023-2026 Raja Kolli. ***/
 package com.example.paymentservice.common;
 
-import java.time.Duration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.grafana.LgtmStackContainer;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
 public class NonSQLContainerConfig {
-
-    @Bean
-    @ServiceConnection
-    LgtmStackContainer lgtmContainer() {
-        return new LgtmStackContainer(DockerImageName.parse("grafana/otel-lgtm:0.30.1"))
-                .withStartupTimeout(Duration.ofMinutes(2));
-    }
 
     @Bean
     @ServiceConnection


### PR DESCRIPTION
As we have moved towards the agent based opentelemetry adding explict LGTM container for integration tests is not necessary